### PR TITLE
Drop final modifier on data services (to allow extending to add caching)

### DIFF
--- a/src/Service/BusinessUnitDataService.php
+++ b/src/Service/BusinessUnitDataService.php
@@ -1,7 +1,7 @@
 <?php
 namespace LarsNieuwenhuizen\Trustpilot\Service;
 
-final class BusinessUnitDataService extends AbstractDataService
+class BusinessUnitDataService extends AbstractDataService
 {
 
     /**

--- a/src/Service/CategoryDataService.php
+++ b/src/Service/CategoryDataService.php
@@ -1,7 +1,7 @@
 <?php
 namespace LarsNieuwenhuizen\Trustpilot\Service;
 
-final class CategoryDataService extends AbstractDataService
+class CategoryDataService extends AbstractDataService
 {
 
     /**

--- a/src/Service/ConsumerDataService.php
+++ b/src/Service/ConsumerDataService.php
@@ -1,7 +1,7 @@
 <?php
 namespace LarsNieuwenhuizen\Trustpilot\Service;
 
-final class ConsumerDataService extends AbstractDataService
+class ConsumerDataService extends AbstractDataService
 {
 
     /**


### PR DESCRIPTION
Hey @LarsNieuwenhuizen thanks so much for this repo!
I'm raising this PR to drop the `final` modifiers on the data services as I need to cache the response, so in my codebase I need to be able to extend these classes to wrap them in a caching layer.

For now, I'll update my `composer.json` to point to my forked version, but it would be great if you would consider merging this into your repo :)

Thanks!